### PR TITLE
Dockerize a basic shiny app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM --platform=arm64 transitionmonitordockerregistry.azurecr.io/rmi_pacta:2021q4_1.0.0
+
+RUN apt-get update && apt-get install -y \
+  sudo \
+  gdebi-core \
+  pandoc \
+  pandoc-citeproc \
+  libcurl4-gnutls-dev \
+  libcairo2-dev \
+  libxt-dev \
+  xtail \
+  wget
+
+# install packages for dependency resolution and installation
+RUN Rscript -e "install.packages('pak')"
+RUN Rscript -e "pak::pkg_install('renv')"
+
+# Download and install shiny server
+RUN wget --no-verbose https://download3.rstudio.org/ubuntu-14.04/x86_64/VERSION -O "version.txt" && \
+  VERSION=$(cat version.txt)  && \
+  wget --no-verbose "https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-$VERSION-amd64.deb" -O ss-latest.deb && \
+  gdebi -n ss-latest.deb && \
+  rm -f version.txt ss-latest.deb && \
+  . /etc/environment && \
+  R -e "pak::pkg_install(c('shiny', 'rmarkdown'))" && \
+  cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
+  chown shiny:shiny /var/lib/shiny-server
+
+EXPOSE 3838
+
+COPY shiny-server.sh /usr/bin/shiny-server.sh
+COPY ./app/* /srv/shiny-server/
+
+# install workflow dependencies
+RUN Rscript -e "\
+  workflow_pkgs <- renv::dependencies('/srv/shiny-server')[['Package']]; \
+  pak::pkg_install(workflow_pkgs); \
+  "  
+
+# run app
+CMD ["/usr/bin/shiny-server"]

--- a/app/app.R
+++ b/app/app.R
@@ -1,0 +1,56 @@
+library(shiny)
+
+# Define UI for app that draws a histogram ----
+ui <- fluidPage(
+
+  # App title ----
+  titlePanel("Hello Shiny!"),
+
+  # Sidebar layout with input and output definitions ----
+  sidebarLayout(
+
+    # Sidebar panel for inputs ----
+    sidebarPanel(
+
+      # Input: Slider for the number of bins ----
+      sliderInput(
+        inputId = "bins",
+        label = "Number of bins:",
+        min = 1,
+        max = 50,
+        value = 30
+      )
+    ),
+
+    # Main panel for displaying outputs ----
+    mainPanel(
+
+      # Output: Histogram ----
+      plotOutput(outputId = "distPlot")
+    )
+  )
+)
+
+# Define server logic required to draw a histogram ----
+server <- function(input, output) {
+  # Histogram of the Old Faithful Geyser Data ----
+  # with requested number of bins
+  # This expression that generates a histogram is wrapped in a call
+  # to renderPlot to indicate that:
+  #
+  # 1. It is "reactive" and therefore should be automatically
+  #    re-executed when inputs (input$bins) change
+  # 2. Its output type is a plot
+  output$distPlot <- renderPlot({
+    x <- faithful$waiting
+    bins <- seq(min(x), max(x), length.out = input$bins + 1)
+
+    hist(x,
+      breaks = bins, col = "#007bc2", border = "white",
+      xlab = "Waiting time to next eruption (in mins)",
+      main = "Histogram of waiting times"
+    )
+  })
+}
+
+shinyApp(ui = ui, server = server)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.2"
+
+services:
+  pacta_dash:
+    container_name: pacta_dash_prototype
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: always
+    user: 'root'
+    ports:
+      - '3838:3838'
+    volumes:
+      - 'shiny_logs:/var/log/shiny-server'
+
+volumes:
+  shiny_logs:

--- a/shiny-server.sh
+++ b/shiny-server.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Make sure the directory for individual app logs exists
+mkdir -p /var/log/shiny-server
+chown shiny.shiny /var/log/shiny-server
+
+if [ "$APPLICATION_LOGS_TO_STDOUT" != "false" ]; then
+	# push the "real" application logs to stdout with xtail in detached mode
+	exec xtail /var/log/shiny-server/ &
+fi
+
+# start shiny server
+exec shiny-server 2>&1


### PR DESCRIPTION
This PR adds a straightforward dockerized Hello Shiny app based on the `rmi_pacta` base image. This will serve as the basis for a shiny app, to serve the output of the interactive report. 
