### PR TITLE
Use ghcr.io/rmi-pacta/workflow.transition.monitor:main as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=arm64 transitionmonitordockerregistry.azurecr.io/rmi_pacta:2021q4_1.0.0
+FROM --platform=arm64 ghcr.io/rmi-pacta/workflow.transition.monitor:main
 
 RUN apt-get update && apt-get install -y \
   sudo \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     ports:
       - '3838:3838'
     volumes:
+      - /Users/jdhoffa/github/pacta-data:/pacta-data
+      - /Users/jdhoffa/github/workflow.transition.monitor/working_dir:/bound/working_dir
       - 'shiny_logs:/var/log/shiny-server'
 
 volumes:


### PR DESCRIPTION
And specify volume mounts in the `docker-compose.yml`